### PR TITLE
feat: load server config from env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+SERVER_URL=http://localhost:1234
+AUTH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -100,3 +100,14 @@ This is a personal project. While the code is public for anyone to use and learn
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=YorkieDev/LMStudioWebUI&type=Date)](https://star-history.com/#YorkieDev/LMStudioWebUI&Date)
+
+## Environment Configuration
+
+Create a `.env` file in the project root to prefill connection details when the page loads:
+
+```
+SERVER_URL=http://localhost:1234
+AUTH_TOKEN=
+```
+
+`SERVER_URL` is required and should point to your LM Studio server. `AUTH_TOKEN` is optional and may be left blank if the server does not require authentication.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,15 @@
+import { parse } from 'https://cdn.jsdelivr.net/npm/dotenv@16.4.5/+esm';
+
+let env = {};
+try {
+  const response = await fetch('.env');
+  const text = await response.text();
+  env = parse(text);
+} catch (err) {
+  console.error('Failed to load .env', err);
+}
+
+window.CONFIG = {
+  SERVER_URL: env.SERVER_URL || '',
+  AUTH_TOKEN: env.AUTH_TOKEN || ''
+};

--- a/index.html
+++ b/index.html
@@ -418,12 +418,14 @@
   </div>
   <!-- Custom context menu for deleting chats -->
   <div id="context-menu">Delete Chat</div>
-  
+
+  <script type="module" src="config.js"></script>
   <script>
     // Global variables
       const chatContainer = document.getElementById('chat-container');
       const userInput = document.getElementById('user-input');
       const serverUrlInput = document.getElementById('server-url');
+      serverUrlInput.value = window.CONFIG?.SERVER_URL || '';
       const authTokenInput = document.getElementById('auth-token');
       const connectButton = document.getElementById('connect-button');
       const connectionStatus = document.getElementById('connection-status');
@@ -442,7 +444,7 @@
       let currentModel = '';
       let pendingImage = null;
       let authToken = window.CONFIG?.AUTH_TOKEN || '';
-      if (authToken && authTokenInput) {
+      if (authTokenInput) {
         authTokenInput.value = authToken;
       }
     


### PR DESCRIPTION
## Summary
- expose env-based configuration in the browser
- document `.env` usage for default server URL and auth token

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893a420fb7c832aa6a67e365fc3217c