### PR TITLE
feat: support basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Create a `.env` file in the project root to prefill connection details when the 
 
 ```
 SERVER_URL=http://localhost:1234
-AUTH_TOKEN=
+AUTH_TOKEN=alice:secret
 ```
 
-`SERVER_URL` is required and should point to your LM Studio server. `AUTH_TOKEN` is optional and may be left blank if the server does not require authentication.
+`SERVER_URL` is required and should point to your LM Studio server. `AUTH_TOKEN` may either be a bearer token or a `username:password` pair for servers using HTTP Basic authentication. Leave it blank if the server does not require authentication.
 
 ## Long-term Chat Memory
 

--- a/index.html
+++ b/index.html
@@ -478,7 +478,15 @@
       if (authTokenInput) {
         authTokenInput.value = authToken;
       }
-    
+
+      function applyAuthHeader(headers) {
+        if (authToken) {
+          headers['Authorization'] = authToken.includes(':')
+            ? `Basic ${btoa(authToken)}`
+            : `Bearer ${authToken}`;
+        }
+      }
+
     // Chat management: each chat has an id, name, and messages array.
     let chats = [];
     let currentChat = null;
@@ -701,7 +709,7 @@
         const serverUrl = normalizeServerUrl(serverUrlInput.value.trim());
         try {
           const headers = { 'Content-Type': 'application/json' };
-          if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+          applyAuthHeader(headers);
           await fetch(`${serverUrl}/v1/model/eject`, {
             method: 'POST',
             headers,
@@ -768,7 +776,7 @@
         try {
           updateConnectionStatus('Connecting...', false);
           const headers = { 'Content-Type': 'application/json' };
-          if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+          applyAuthHeader(headers);
           const response = await fetch(`${serverUrl}/v1/models`, {
             method: 'GET',
             headers
@@ -862,7 +870,7 @@
     
         try {
           const headers = { 'Content-Type': 'application/json' };
-          if (authToken) headers['Authorization'] = `Bearer ${authToken}`;
+          applyAuthHeader(headers);
           const response = await fetch(`${serverUrl}/v1/chat/completions`, {
             method: 'POST',
             headers,


### PR DESCRIPTION
## Summary
- allow username:password pairs for HTTP Basic auth by encoding credentials and applying Authorization header
- document Basic auth usage in environment configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689487162e78832a8015528a18fb1eaa