### PR TITLE
Allow frontend to read .env by serving dotfiles

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,7 +25,8 @@ db.serialize(() => {
 
 const app = express();
 app.use(express.json({limit: '10mb'}));
-app.use(express.static(path.join(__dirname)));
+// Allow serving dotfiles so the frontend can fetch the .env configuration
+app.use(express.static(path.join(__dirname), { dotfiles: 'allow' }));
 
 // Return all chats with their messages
 app.get('/api/chats', (req, res) => {


### PR DESCRIPTION
## Summary
- Serve dotfiles in Express static middleware to expose `.env` to the frontend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894f727bbf8832ab2f11e2afc6a9b1d